### PR TITLE
Fixed oversized user avatars

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,6 +261,7 @@ module.exports = class BetterStatusIndicators extends Plugin {
     this.inject('bsi-mobile-status-default-mask', avatarModule, 'default', ([ props ], res) => {
       const { size, status, isMobile, isTyping } = props;
       const foreignObject = findInReactTree(res, n => n?.type === 'foreignObject');
+      foreignObject.props.children.props.style = {width: "40px"};
 
       if (status && isMobile && !isTyping) {
         res.props['data-bsi-status'] = status;


### PR DESCRIPTION
This definitely isn't the best way of doing this but I had a problem where mobile users' avatars were oversized (seen below)
![image](https://user-images.githubusercontent.com/52337413/112177492-5a099280-8bcf-11eb-9478-67d1b0877061.png)

So I simply set the width of the child avatar to 40px explicitly to fix that. I'm also not sure if this issue is only me but this shouldn't effect other users of the plugin unless they also have a plugin that resizes the avatars.

This is my first pull request so suggestions/critiques are welcome.