### PR TITLE
prevent mobile mask from showing if useMobileAvatarStatus is off & fix settings change restart prompt modals being invisible

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -254,8 +254,9 @@ module.exports = class BetterStatusIndicators extends Plugin {
   }
 
   showHWADisabledNotice () {
-    const handleButtonClick = () => openModal(() => (
+    const handleButtonClick = () => openModal((e) => (
       <Confirm
+        {...e}
         header={Messages.SWITCH_HARDWARE_ACCELERATION}
         confirmText={Messages.OKAY}
         cancelText={Messages.CANCEL}

--- a/lib/stores/settingsSections.js
+++ b/lib/stores/settingsSections.js
@@ -5,7 +5,8 @@ const { open: openModal } = require('powercord/modal');
 const { getSetting, toggleSetting } = powercord.api.settings._fluxProps('better-status-indicators');
 
 function handleSettingChangeAndReload (headerText, setting) {
-  return openModal(() => React.createElement(Confirm, {
+  return openModal((e) => React.createElement(Confirm, {
+    ...e,
     header: headerText,
     confirmText: Messages.OKAY,
     cancelText: Messages.CANCEL,

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Better Status Indicators",
-  "version": "1.15.7",
+  "version": "1.15.8",
   "description": "Provides enhanced functionality and personalization to statuses.",
   "author": "M|-|4r13y ツ#1051",
   "license": "OSL-3.0"

--- a/patches/avatar.jsx
+++ b/patches/avatar.jsx
@@ -129,11 +129,18 @@ module.exports = (main) => {
     }
 
     const avatarHint = findInReactTree(res, n => n.props?.hasOwnProperty('mask'));
+    const useEnhancedAvatarStatus = main.ModuleManager.isEnabled('avatar-statuses');
+    const useMobileAvatarStatus = getSetting('mobileAvatarStatus', true) || useEnhancedAvatarStatus;
+
     if (avatarHint) {
       const isRadialStatusEnabled = main.ModuleManager.isEnabled('radial-status');
       const isEnhancedAvatarStatusEnabled = main.ModuleManager.isEnabled('avatar-statuses');
 
-      if (isEnhancedAvatarStatusEnabled && !props.isMobile) {
+      if (useMobileAvatarStatus || isEnhancedAvatarStatusEnabled && !props.isMobile) {
+        avatarHint.props.mask = `svg-mask-avatar-status-round-${avatarHint.props.width}`;
+      } else if (!useMobileAvatarStatus && isRadialStatusEnabled) {
+        avatarHint.props.mask = 'svg-mask-avatar-default';
+      } else if (!useMobileAvatarStatus) {
         avatarHint.props.mask = `svg-mask-avatar-status-round-${avatarHint.props.width}`;
       } else {
         avatarHint.props.mask = !props.isMobile && isRadialStatusEnabled ? 'svg-mask-avatar-default' : avatarHint.props.mask;

--- a/patches/avatar.jsx
+++ b/patches/avatar.jsx
@@ -136,7 +136,7 @@ module.exports = (main) => {
       const isRadialStatusEnabled = main.ModuleManager.isEnabled('radial-status');
       const isEnhancedAvatarStatusEnabled = main.ModuleManager.isEnabled('avatar-statuses');
 
-      if (useMobileAvatarStatus || isEnhancedAvatarStatusEnabled && !props.isMobile) {
+      if ((useMobileAvatarStatus || isEnhancedAvatarStatusEnabled) && !props.isMobile) {
         avatarHint.props.mask = `svg-mask-avatar-status-round-${avatarHint.props.width}`;
       } else if (!useMobileAvatarStatus && isRadialStatusEnabled) {
         avatarHint.props.mask = 'svg-mask-avatar-default';


### PR DESCRIPTION
Before (No Radial Status, Mobile Indicator Off):
![image](https://user-images.githubusercontent.com/98427312/178323598-bf1526c4-0f7b-49d3-af9c-cd5bddd4e8db.png)

Before (Radial Status, Mobile Indicator Off):
![image](https://user-images.githubusercontent.com/98427312/178323567-ab66e73e-d896-41cf-be8e-570056699306.png)

After (No Radial Status, Mobile Indicator Off):
![image](https://user-images.githubusercontent.com/98427312/178323731-6c0a9912-d531-45f3-91ed-23733d5111cc.png)

After (Radial Status, Mobile Indicator Off):
![image](https://user-images.githubusercontent.com/98427312/178323781-dcd0e3d3-a02b-43c7-9fdf-e136725e9a60.png)


