### PR TITLE
Fix crash

### DIFF
--- a/modules/avatar-statuses/index.js
+++ b/modules/avatar-statuses/index.js
@@ -75,8 +75,7 @@ module.exports = class AvatarStatuses extends Module {
 
         tooltip.props.children = (props) => {
           const res = children(props);
-
-          const child = res.props.children.find(c => c && c.props)
+          const child = res.props.children.find(c => c && c.props);
 
           child.props = { ...child.props,
             mask: `url(#svg-mask-status-online-${client})`

--- a/modules/avatar-statuses/index.js
+++ b/modules/avatar-statuses/index.js
@@ -76,7 +76,9 @@ module.exports = class AvatarStatuses extends Module {
         tooltip.props.children = (props) => {
           const res = children(props);
 
-          res.props.children[0].props = { ...res.props.children[0].props,
+          const child = res.props.children.find(c => c && c.props)
+
+          child.props = { ...child.props,
             mask: `url(#svg-mask-status-online-${client})`
           };
 


### PR DESCRIPTION
Sometimes on line 79 `res.props.children[0]` is false, causing it to crash. I don't know why this differs sometimes but simply finding the correct child and then applying the mask seems to work perfectly.